### PR TITLE
Removed the for loop, to prevent duplicates.

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,13 +13,11 @@
 		{% include header.html %}
 	</header>
 	<div class="container">
-		{% for post in site.posts %}
-			<article>
-				<h1><a href="{{ site.base_url }}{{ page.url }}">{{ page.title }}</a></h1>
-				<p>{{ page.date | date_to_string }}</p>
-				<p>{{ content }}</p>
-			</article>
-		{% endfor %}
+		<article>
+			<h1><a href="{{ site.base_url }}{{ page.url }}">{{ page.title }}</a></h1>
+			<p>{{ page.date | date_to_string }}</p>
+			<p>{{ content }}</p>
+		</article>
 	</div>
 	<footer>
 		{% include footer.html %}


### PR DESCRIPTION
This for loop causes the post to reprint one time for every new post that is added to the _posts folder. That means if you've written 3 posts, and you browse to the page for one, you'll actually see that one post printed 3 times.
